### PR TITLE
Bug 983973

### DIFF
--- a/careers/base/static/css/base.css
+++ b/careers/base/static/css/base.css
@@ -228,13 +228,7 @@ figure {
 }
 
 .masthead-logo {
-    padding: 30px 0 20px;
     margin: 0;
-    font-size: 2.3em;
-
-    -webkit-transition: font-size 0.1s;
-       -moz-transition: font-size 0.1s;
-            transition: font-size 0.1s;
 }
 
 .masthead-logo a:not(:hover) {
@@ -282,7 +276,8 @@ figure {
         left: 0;
         z-index: 100;
         width: 100%;
-        min-height: 100px;
+        max-height: 100px;
+        min-height: 60px;
         background: #f5f1e8 url(/static/img/bg-sand.png) repeat;
         background: url(/static/img/bg-gradient-sand.png) repeat-x 0 0,
                     url(/static/img/bg-sand.png) repeat 0 0, #f5f1e8;
@@ -293,7 +288,8 @@ figure {
     }
 
     .js-enabled .masthead .contain {
-       height: 100px;
+       max-height: 100px;
+       height: auto;
        overflow: hidden;
     }
 
@@ -305,6 +301,11 @@ figure {
 @media (min-width: 940px) {
    .masthead-logo {
         display: block;
+        padding-top: 10px;
+    }
+
+    .masthead-logo.expanded {
+        padding-top: 28px;
     }
 }
 

--- a/careers/base/static/js/base.js
+++ b/careers/base/static/js/base.js
@@ -203,13 +203,9 @@ Mozilla.Test = (function(w, $) {
 
         initializedBefore = true;
 
-        var masthead = document.getElementsByClassName('masthead')[0];
-        var contain = document.getElementsByClassName('contain')[0];
-        var logo = document.getElementsByClassName('masthead-logo')[0];
+        var $logo = $('.masthead-logo');
 
         var spanLength = 100;
-        var fullStop = true;
-        var reducedBefore = false;
 
         function reducedHeaderScrollSpy() {
             ticking = false;
@@ -218,25 +214,12 @@ Mozilla.Test = (function(w, $) {
             var scrollTop = $window.scrollTop();
             var ratio = scrollTop/spanLength;
 
-            if (scrollTop <= spanLength) {
-                fullStop = false;
-                reducedBefore = true;
-
-                contain.style.maxHeight = (100 - (50*ratio)) + 'px';
-                masthead.style.minHeight = contain.style.maxHeight;
-
-                logo.style.paddingTop = (30 - (24*ratio)) + 'px';
-                logo.style.paddingBottom = (20 - (20*ratio)) + 'px';
-                logo.style.fontSize = (2.3 - ratio)+'em';
-            } else if (!fullStop) {
-                fullStop = true;
-                reducedBefore = true;
-
-                contain.style.maxHeight = masthead.style.minHeight = '50px';
-
-                logo.style.paddingTop = '6px';
-                logo.style.paddingBottom = '0';
-                logo.style.fontSize = '2em';
+            if (ratio < 1 && !$logo.hasClass('expanded')) {
+                $logo.addClass('expanded');
+            } else if (ratio < 1) {
+                $logo[0].style.paddingTop = 28 - (18*ratio) + 'px';
+            } else if (ratio > 1 && ($logo.hasClass('expanded') || $logo.attr('style'))) {
+                $logo.removeAttr('style').removeClass('expanded');
             }
         };
 
@@ -246,12 +229,7 @@ Mozilla.Test = (function(w, $) {
 
         function handleResize() {
             ticking = false;
-            if (isSmallScreen()) {
-                if (reducedBefore) {
-                    contain.style.maxHeight = 'none';
-                    masthead.style.minHeight = '60px';
-                }
-            } else if (!initializedBefore) {
+            if (!initializedBefore) {
                 initReducedHeaderScrollSpy();
             } else {
                 /* Big screen and scrollspy already initialized
@@ -259,7 +237,6 @@ Mozilla.Test = (function(w, $) {
                 * To update masthead / container
                 * in accordance to current scroll position
                 */
-                fullStop = false;
                 reducedHeaderScrollSpy();
             }
         }

--- a/careers/base/templates/base/header.html
+++ b/careers/base/templates/base/header.html
@@ -18,9 +18,9 @@
             </li>
           </ul>
         </nav>
-        <h2 class="masthead-logo">
+        <h2 class="masthead-logo expanded">
           <a href="{{ url('careers.home') }}">
-            Mozilla Careers
+            <img alt="Mozilla Careers" src="https://cloud.githubusercontent.com/assets/584352/9439604/13d932de-4a71-11e5-85d0-5447c2d870c9.png"/>
           </a>
         </h2>
     </div>


### PR DESCRIPTION
- Use CSS classes instead of updating inline-styles properties to apply expanded / reduced states
- Use `body`'s background to make it look like `header.masthead` is shrinking on scroll.
- Less DOM manipulations
- So much simpler
- Seems not to produce resize/refresh edge-cases of previous implementation
